### PR TITLE
Modify scripts to enable persistent state

### DIFF
--- a/bin/make_cloud_config.sh
+++ b/bin/make_cloud_config.sh
@@ -44,8 +44,8 @@ vm_types:
     security_groups: [boshdefault]
 - name: concourse_worker
   cloud_properties:
-    instance_type: m3.medium
-    ephemeral_disk: {size: 3000, type: gp2}
+    instance_type: m3.large
+    ephemeral_disk: {size: 30000, type: gp2}
     security_groups: [boshdefault]
 - name: default
   cloud_properties:

--- a/bin/make_manifest_concourse.sh
+++ b/bin/make_manifest_concourse.sh
@@ -43,7 +43,6 @@ instance_groups:
     properties:
       # replace with your CI's externally reachable URL e.g https://blah
       external_url: $CONCOURSE_URL
-
       # configure GitHub auth
       github_auth:
         authorize:
@@ -53,13 +52,19 @@ instance_groups:
         client_secret: $GITHUB_CLIENT_SECRET
 
       postgresql_database: &atc_db atc
-
-      publicly_viewable: true # anyone can view the main pipeline page
-
   - name: tsa
     release: concourse
     properties: {}
 
+- name: db
+  instances: 1
+  vm_type: concourse_db
+  stemcell: trusty
+  # choose a disk type from the cloud-config
+  persistent_disk_type: $DISK_TYPE
+  azs: [z1]
+  networks: [{name: ops_services}]
+  jobs:
   - name: postgresql
     release: concourse
     properties:
@@ -69,6 +74,13 @@ instance_groups:
         role: dbrole
         password: $DB_PASSWORD
 
+- name: worker
+  instances: 1
+  vm_type: concourse_worker
+  stemcell: trusty
+  azs: [z1]
+  networks: [{name: ops_services}]
+  jobs:
   - name: groundcrew
     release: concourse
     properties: {}


### PR DESCRIPTION
By having the postgresql job run in the same instance as concourse, the persistent disk was not being set.  This caused all pipelines and teams to be wiped upon upgrading concourse versions.

`publicly_viewable` was removed in version 2.0.0 so I removed it from the config.

When deploying concourse with the workers running on a m3.medium an error prevented the deploy from succeeding.  Giving the workers more memory fixes this.
